### PR TITLE
Fix #3 - New links to download.cgeo.org

### DIFF
--- a/app/models/BuildKind.scala
+++ b/app/models/BuildKind.scala
@@ -6,13 +6,13 @@ abstract class UpToDateKind(name: String, url: Option[String]) extends BuildKind
 
 object Release extends UpToDateKind("release", Some("https://play.google.com/store/apps/details?id=cgeo.geocaching"))
 
-object Deployment extends UpToDateKind("deployment", Some("http://cgeo.org/cgeo-release.apk"))
+object Deployment extends UpToDateKind("deployment", Some("http://download.cgeo.org/cgeo-release.apk"))
 
 object Legacy extends UpToDateKind("legacy", Some("https://play.google.com/store/apps/details?id=cgeo.geocaching"))
 
-object ReleaseCandidate extends UpToDateKind("rc", Some("http://cgeo.org/cgeo-RC.apk"))
+object ReleaseCandidate extends UpToDateKind("rc", Some("http://download.cgeo.org/cgeo-RC.apk"))
 
-object NightlyBuild extends UpToDateKind("nightly", Some("http://cgeo.org/nightly.html"))
+object NightlyBuild extends UpToDateKind("nightly", Some("http://download.cgeo.org/cgeo-nightly.apk"))
 
 object DeveloperBuild extends UpToDateKind("developer", Some("https://github.com/cgeo/cgeo"))
 

--- a/app/models/Status.scala
+++ b/app/models/Status.scala
@@ -33,13 +33,13 @@ object Status {
     Some(Map("icon" -> "attribute_climbing",
       "message" -> "New release candidate available.\nClick to install.",
       "message_id" -> "status_new_rc",
-      "url" ->  "http://cgeo.org/cgeo-RC.apk"))
+      "url" ->  "http://download.cgeo.org/cgeo-RC.apk"))
 
   private val newNightly =
     Some(Map("icon" -> "attribute_climbing",
       "message" -> "New nightly build available.\nClick to install.",
       "message_id" -> "status_new_nightly",
-      "url" ->  "http://cgeo.org/c-geo-nightly.apk"))
+      "url" ->  "http://download.cgeo.org/cgeo-nightly.apk"))
 
   def nothing = Database.getMessage.map(_.mapValues(_.toString).toMap)
 


### PR DESCRIPTION
For notification itself and for the status webpage.
All targets should already work now, and this should be used **before** going to the new website to assure availability.
Links are tested, so it can be merged at any time.

