### PR TITLE
Fix #10: Use Google Play URL as RC download link

### DIFF
--- a/app/models/Status.scala
+++ b/app/models/Status.scala
@@ -34,7 +34,7 @@ class Status @Inject() (database: Database) {
 
   private val newRC = Message(
     "New release candidate available.\nClick to install.",
-    Some("status_new_rc"), Some("attribute_climbing"), Some("http://download.cgeo.org/cgeo-RC.apk")
+    Some("status_new_rc"), Some("attribute_climbing"), Some("https://play.google.com/store/apps/details?id=cgeo.geocaching")
   )
 
   private val newNightly = Message(


### PR DESCRIPTION
As we changed the distribution of the RC from publication of the download-link to using the Google Play beta channel, users should also download any updates from Google Play.
Otherwise we wont get any crash reports and statistics from there.